### PR TITLE
get uppercase key list with configparser for cfg file

### DIFF
--- a/gambas/manager.py
+++ b/gambas/manager.py
@@ -41,7 +41,8 @@ class ConfigContentManager(BaseContentManager):
       self.config_parser.read_string(content)
 
   def get_key_list(self):
-    return self.config_parser.defaults().keys()
+    key_list = self.config_parser.defaults().keys()
+    return list(map(lambda x: x.upper(), key_list))
 
 
 class JsonContentManager(BaseContentManager):

--- a/gambas/tests/conftest.py
+++ b/gambas/tests/conftest.py
@@ -10,10 +10,10 @@ sys.path.append(BASE_DIR)
 TEST_FOLDER = os.path.join(BASE_DIR, "files")
 
 TEST_DEFAULT_DICT = {
-    "test_user": "user",
-    "test_breakfast": "salad",
-    "test_lunch": "gambas",
-    "test_dinner": "ssam"
+    "TEST_USER": "user",
+    "TEST_BREAKFAST": "salad",
+    "TEST_LUNCH": "gambas",
+    "TEST_DINNER": "ssam"
 }
 
 
@@ -34,7 +34,7 @@ def get_filepath_with_creating_file(
   with open(filepath, "w", encoding="utf-8") as f:
     if filetype == "cfg":
       for test_key, test_value in sliced_item_list:
-        f.write(f'{test_key.upper()}="{test_value}"\n')
+        f.write(f'{test_key}="{test_value}"\n')
     elif filetype == "json":
       json.dump(dict(sliced_item_list), f, ensure_ascii=False, indent="\t")
 


### PR DESCRIPTION
close #21

현재 config parser는 key list를 무조건 lower로 반환합니다.
flask에서는 cfg나 json을 configuration file로 쓸 때 key가 무조건 upper여야 인식을 하므로,
이를 변경합니다.