### PR TITLE
Issue26.check keys with multiline value

### DIFF
--- a/gambas/manager.py
+++ b/gambas/manager.py
@@ -26,16 +26,16 @@ class BaseContentManager(metaclass=ABCMeta):
 class ConfigContentManager(BaseContentManager):
   def __init__(self, filepath):
     super().__init__(filepath)
-    self.config = {}
+    self.config_dict = {}
     self._read_file()
 
   def _read_file(self):
     filepath = self.get_filepath()
     with open(filepath, mode="rb") as config_file:
-      exec(compile(config_file.read(), filepath, "exec"), None, self.config)
+      exec(compile(config_file.read(), filepath, "exec"), None, self.config_dict)
 
   def get_key_list(self):
-    return self.config.keys()
+    return self.config_dict.keys()
 
 
 class JsonContentManager(BaseContentManager):

--- a/gambas/manager.py
+++ b/gambas/manager.py
@@ -1,4 +1,3 @@
-import configparser
 import json
 from abc import abstractmethod, ABCMeta
 
@@ -27,33 +26,19 @@ class BaseContentManager(metaclass=ABCMeta):
 class ConfigContentManager(BaseContentManager):
   def __init__(self, filepath):
     super().__init__(filepath)
-    self.config_parser = configparser.ConfigParser(allow_no_value=True)
-    self.config_parser.optionxform = str  # NOTE: not to change keys as lower case charactors
+    self.config = {}
     self._read_file()
 
   def _read_file(self):
     filepath = self.get_filepath()
-    with open(filepath) as config_file:
-      content = config_file.read()
-    try:
-      self.config_parser.read_string(content)
-    except configparser.MissingSectionHeaderError:
-      content = f"{DUMMY_SECTION}{content}"
-      self.config_parser.read_string(content)
-
-    config_paser_key_list = self.config_parser.defaults().keys()
-    config = {}
     with open(filepath, mode="rb") as config_file:
-      exec(compile(config_file.read(), filepath, "exec"), config)
+      exec(compile(config_file.read(), filepath, "exec"), self.config)
 
-    self.config_dict = {
-        k: v
-        for k, v in config.items()
-        if k in config_paser_key_list
-    }
+    self.config.pop('__builtins__')
+    print(self.config)
 
   def get_key_list(self):
-    return self.config_dict.keys()
+    return self.config.keys()
 
 
 class JsonContentManager(BaseContentManager):

--- a/gambas/manager.py
+++ b/gambas/manager.py
@@ -41,6 +41,7 @@ class ConfigContentManager(BaseContentManager):
       content = f"{DUMMY_SECTION}{content}"
       self.config_parser.read_string(content)
 
+    config_paser_key_list = self.config_parser.defaults().keys()
     config = {}
     with open(filepath, mode="rb") as config_file:
       exec(compile(config_file.read(), filepath, "exec"), config)
@@ -48,7 +49,7 @@ class ConfigContentManager(BaseContentManager):
     self.config_dict = {
         k: v
         for k, v in config.items()
-        if k in self.config_parser.defaults().keys()
+        if k in config_paser_key_list
     }
 
   def get_key_list(self):

--- a/gambas/manager.py
+++ b/gambas/manager.py
@@ -32,10 +32,7 @@ class ConfigContentManager(BaseContentManager):
   def _read_file(self):
     filepath = self.get_filepath()
     with open(filepath, mode="rb") as config_file:
-      exec(compile(config_file.read(), filepath, "exec"), self.config)
-
-    self.config.pop('__builtins__')
-    print(self.config)
+      exec(compile(config_file.read(), filepath, "exec"), None, self.config)
 
   def get_key_list(self):
     return self.config.keys()

--- a/gambas/manager.py
+++ b/gambas/manager.py
@@ -41,8 +41,18 @@ class ConfigContentManager(BaseContentManager):
       content = f"{DUMMY_SECTION}{content}"
       self.config_parser.read_string(content)
 
+    config = {}
+    with open(filepath, mode="rb") as config_file:
+      exec(compile(config_file.read(), filepath, "exec"), config)
+
+    self.config_dict = {
+        k: v
+        for k, v in config.items()
+        if k in self.config_parser.defaults().keys()
+    }
+
   def get_key_list(self):
-    return self.config_parser.defaults().keys()
+    return self.config_dict.keys()
 
 
 class JsonContentManager(BaseContentManager):


### PR DESCRIPTION
close #26 
value가 multiline인 경우, configparser에서는 괄호도 key로 인식합니다.
(예시는 위 이슈 본문으로 적어놨습니다)
따라서 multiline value일 때도 key를 제대로 확인할 수 있도록 코드 변경을 하였습니다!